### PR TITLE
Update mk.prebuilt-data

### DIFF
--- a/mk.prebuilt-data
+++ b/mk.prebuilt-data
@@ -8,7 +8,7 @@ all:
 	unxz prebuilt-data.tar.xz
 	tar -xvf prebuilt-data.tar
 	rm prebuilt-data.tar
-	rm prebuilt-data.tar.xz
+#	rm prebuilt-data.tar.xz
 
 clean:
 	rm -f $(DATA)/gcide.txt


### PR DESCRIPTION
Remove line 11 to avoid this error:
```
rm: impossibile rimuovere 'prebuilt-data.tar.xz': File o directory non esistente
mk.prebuilt-data:6: set di istruzioni per l'obiettivo "all" non riuscito
make: *** [all] Errore 1
```