### PR TITLE
Add SilverDict integration

### DIFF
--- a/server/Diogenes/Perseus.pm
+++ b/server/Diogenes/Perseus.pm
@@ -660,9 +660,9 @@ my $old_pdf_link = sub {
 
 my $silverdict_link = sub {
     my $word = shift;
-    my $href = "http://localhost:2628/api/query/Diogenes/$word";
+    my $href = "http://localhost:2628/?group=Diogenes&key=$word";
     # We'll use a popup window to view the definition
-    return qq{ <a onClick="window.open('$href', 'SilverDict', 'width=800,height=600,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no'); return false;" href="#"><i>SilverDict</i></a>};
+    return qq{ <a onClick="window.open('$href', 'SilverDict', 'width=500,height=600,left='+ (window.screen.width - 500) +',top='+ (window.screen.height - 600)); return false;" href="#"><i>SilverDict</i></a>};
 };
 
 our $munge_element = sub {

--- a/server/Diogenes/Perseus.pm
+++ b/server/Diogenes/Perseus.pm
@@ -662,7 +662,7 @@ my $silverdict_link = sub {
     my $word = shift;
     my $href = "http://localhost:2628/api/query/Diogenes/$word";
     # We'll use a popup window to view the definition
-    return qq{<a onClick="window.open('$href', 'SilverDict', 'width=800,height=600,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no'); return false;" href="#"><i>SilverDict</i></a>};
+    return qq{ <a onClick="window.open('$href', 'SilverDict', 'width=800,height=600,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no'); return false;" href="#"><i>SilverDict</i></a>};
 };
 
 our $munge_element = sub {

--- a/server/Diogenes/Perseus.pm
+++ b/server/Diogenes/Perseus.pm
@@ -658,6 +658,13 @@ my $old_pdf_link = sub {
     return qq{ <a onClick="openPDF('$href')" href="#"><i>OLD</i></a>};
 };
 
+my $silverdict_link = sub {
+    my $word = shift;
+    my $href = "http://localhost:2628/api/query/Diogenes/$word";
+    # We'll use a popup window to view the definition
+    return qq{<a onClick="window.open('$href', 'SilverDict', 'width=800,height=600,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no'); return false;" href="#"><i>SilverDict</i></a>};
+};
+
 our $munge_element = sub {
     my $e = shift;
     $swap_element->($e, 0); # open it
@@ -677,6 +684,7 @@ our $munge_element = sub {
         $out .= '<span style="display:block;text-align:right;">&nbsp;';
         $out .= $tll_pdf_link->($key);
         $out .= $old_pdf_link->($key);
+        $out .= $silverdict_link->($key);
         $out .= '</span></h2>';
         # $out .= '<h2>' . $key . '</h2>';
     }


### PR DESCRIPTION
I am the developer of [SilverDict](https://github.com/Crissium/SilverDict), a web-based dictionary lookup tool that supports DSL, StarDict and MDict. Unlike GoldenDict, it exposes a lookup API (`/api/query/<Group name>/<word>`) that could be easily integrated into other programs, including Diogenes.

I have added a few lines in `server/Diogenes/Perseus.pm` beside the ones that create links pointing to the PDF Latin dictionaries. They create another link pointing to `http://localhost:2628/api/query/Diogenes/$word`, which when clicked, opens a pop-up window showing the definition. For this feature to work, users need to have a local SilverDict installation and create a dictionary group named 'Diogenes' with the languages `el, la`, and add relevant dictionaries. This feature has been tested on Linux desktop (with and without electron) and Android.


![Screenshot](https://github.com/pjheslin/diogenes/assets/91039086/2515151c-1649-41cc-9151-399011507e08)

Edit: it might be better if the server address of SilverDict is configurable instead of hardcoded to localhost.